### PR TITLE
Fix memory game win detection

### DIFF
--- a/memory.html
+++ b/memory.html
@@ -243,6 +243,7 @@
       if (a.dataset.val === b.dataset.val) {
         a.classList.add('matched');
         b.classList.add('matched');
+        matched.push(a, b);
         showTemp(matchMsg, '¡Coincidencia!');
         if (current === 1) { score1++; s1.textContent = score1; }
         else              { score2++; s2.textContent = score2; }


### PR DESCRIPTION
## Summary
- track matched cards so the memory game can detect when all pairs have been found

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a19dcf54f0832f86ebb865678b64e9