### PR TITLE
feat(memory): allow board size selection

### DIFF
--- a/memory.html
+++ b/memory.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Juego de Memoria 10×6</title>
+  <title>Juego de Memoria</title>
   <style>
     :root {
       --color-bg-1: #e74c3c;
@@ -177,7 +177,7 @@
       <a href="./help.html">Info</a>
     </nav>
     <div class="title-container">
-      <h1>Juego de Memoria 10×6</h1>
+      <h1 id="gameTitle">Juego de Memoria</h1>
       <div class="player-turn" id="playerTurn">Turno: Jugador 1 (Rojo)</div>
     </div>
   </header>
@@ -194,7 +194,7 @@
   </section>
 
   <script>
-    const cardsArray = [
+    const allCards = [
       '💩','💩','🐱','🐱','🚗','🚗','🎸','🎸','🍕','🍕',
       '🌟','🌟','🎮','🎮','⚽','⚽','🍔','🍔','🍓','🍓',
       '🎩','🎩','🦄','🦄','🐶','🐶','🎤','🎤','🍍','🍍',
@@ -203,6 +203,19 @@
       '🎻','🎻','🐒','🐒','🌈','🌈','🍉','🍉','⚡','⚡'
     ];
 
+    const boardOptions = {
+      'pequeño': { pairs: 8,  cols: 4 },
+      'mediano': { pairs: 18, cols: 6 },
+      'grande':  { pairs: 30, cols: 10 }
+    };
+
+    let choice = prompt('Elige tamaño del tablero: pequeño, mediano o grande', 'mediano');
+    choice = choice ? choice.toLowerCase() : 'mediano';
+    if (!boardOptions[choice]) choice = 'mediano';
+    const { pairs, cols } = boardOptions[choice];
+    const cardsArray = allCards.slice(0, pairs * 2);
+    const rows = cardsArray.length / cols;
+
     let flipped = [], matched = [];
     let lock = false, current = 1, score1 = 0, score2 = 0;
     const board    = document.getElementById('gameBoard'),
@@ -210,12 +223,16 @@
           s1       = document.getElementById('scorePlayer1'),
           s2       = document.getElementById('scorePlayer2'),
           msg      = document.getElementById('message'),
-          matchMsg = document.getElementById('matchMessage');
+          matchMsg = document.getElementById('matchMessage'),
+          title    = document.getElementById('gameTitle');
+
+    title.textContent = `Juego de Memoria ${cols}×${rows}`;
 
     function shuffle(a) { return a.sort(() => Math.random() - 0.5); }
 
     function createBoard() {
       board.innerHTML = '';
+      board.style.gridTemplateColumns = `repeat(${cols}, var(--card-size))`;
       shuffle(cardsArray).forEach(val => {
         const c = document.createElement('div');
         c.className = 'card';
@@ -243,6 +260,7 @@
       if (a.dataset.val === b.dataset.val) {
         a.classList.add('matched');
         b.classList.add('matched');
+        matched.push(a,b);
         showTemp(matchMsg, '¡Coincidencia!');
         if (current === 1) { score1++; s1.textContent = score1; }
         else              { score2++; s2.textContent = score2; }


### PR DESCRIPTION
## Summary
- allow choosing small, medium, or large board at game start
- update board generation and layout based on selected size
- fix match tracking to end game when all pairs are found

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a58cdef8832f9a4d0a0deca64e58