### PR TITLE
Add secret 1992 key sequence to show visitor count

### DIFF
--- a/gente.html
+++ b/gente.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Visitantes</title>
+  <link rel="stylesheet" href="responsive.css">
+  <link rel="icon" type="image/png" href="img/favicon.png">
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+  <style>
+    body {
+      font-family: 'Press Start 2P', cursive;
+      background: #111;
+      color: #0ff;
+      text-align: center;
+      padding: 20px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Visitantes de olap.es</h1>
+  <p id="contador">Cargando...</p>
+  <script>
+    fetch('https://api.countapi.xyz/get/olap.es/visits')
+      .then(r => r.json())
+      .then(d => {
+        document.getElementById('contador').textContent = d.value + ' personas han entrado';
+      })
+      .catch(() => {
+        document.getElementById('contador').textContent = 'No se pudo obtener el contador';
+      });
+  </script>
+</body>
+</html>

--- a/gente.html
+++ b/gente.html
@@ -6,6 +6,14 @@
   <title>Visitantes</title>
   <link rel="stylesheet" href="responsive.css">
   <link rel="icon" type="image/png" href="img/favicon.png">
+  <!-- Google tag (gtag.js) - replace G-XXXXXXXXXX with your own ID -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-XXXXXXXXXX');
+  </script>
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
   <style>
     body {

--- a/index.html
+++ b/index.html
@@ -6,6 +6,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Olap</title>
   <link rel="icon" type="image/png" href="img/favicon.png">
+  <!-- Google tag (gtag.js) - replace G-XXXXXXXXXX with your own ID -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-XXXXXXXXXX');
+  </script>
   <!-- Pixel font -->
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
   <style>

--- a/index.html
+++ b/index.html
@@ -163,6 +163,22 @@
       requestAnimationFrame(loop);
     }
   </script>
+  <script>
+    fetch("https://api.countapi.xyz/hit/olap.es/visits").catch(() => {});
+    const secret = ["1","9","9","2"];
+    let secretIndex = 0;
+    window.addEventListener("keydown", (e) => {
+      if (e.key === secret[secretIndex]) {
+        secretIndex++;
+        if (secretIndex === secret.length) {
+          window.location.href = "gente.html";
+          secretIndex = 0;
+        }
+      } else {
+        secretIndex = e.key === secret[0] ? 1 : 0;
+      }
+    });
+  </script>
   <script src="touch-controls.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Redirect to new visitors page when pressing 1-9-9-2 on the index page.
- Track index page visits and fetch visit total on the new `gente.html` page.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a71b971454832f90f78078a35ba5a0