### PR TITLE
Add GA4 tracking snippet to all pages

### DIFF
--- a/2058.html
+++ b/2058.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/3ratlla.html
+++ b/3ratlla.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>

--- a/4rayagpt.html
+++ b/4rayagpt.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/Clickometeor.html
+++ b/Clickometeor.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>

--- a/Godshot.html
+++ b/Godshot.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>

--- a/Imagenpes.html
+++ b/Imagenpes.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
+  <link rel="stylesheet" href="responsive.css">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Imagen pes</title>
+  <link rel="icon" type="image/png" href="img/favicon.png">
+</head>
+<body>
+
+</body>
+</html>

--- a/Laberintocursor.html
+++ b/Laberintocursor.html
@@ -2,6 +2,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8" />
@@ -49,7 +58,7 @@
       z-index: 10;
     }
 
-    .menu-button, .info-button {
+    .game-buttons {
       position: absolute;
       top: 20px;
       background-color: white;
@@ -64,7 +73,7 @@
     }
 
     .menu-button { left: 20px; }
-    .info-button { left: 130px; }
+    .help-button { left: 130px; }
 
     .nivel-indicador {
       position: absolute;
@@ -129,8 +138,8 @@
 <body>
 
 <div id="pantalla-inicio">
-  <a href="./index.html" class="menu-button">Menú</a>
-  <a href="./info.html" class="info-button">Info</a>
+  <a href="./index.html" class="menu-button game-buttons">Menú</a>
+  <button class="help-button game-buttons" data-help="Usa el cursor para llegar al otro lado sin tocar las paredes.">Info</button>
   <p>¡Hola! Bienvenido al laberinto.<br> Usa el cursor para llegar al otro lado sin tocar las paredes.</p>
   <button class="btn-comenzar" onclick="iniciarJuego()" id="btnStart">▶</button>
   <img id="flecha" src="https://png.pngtree.com/png-clipart/20220122/ourmid/pngtree-direction-arrow-red-irregular-triangle-png-image_4362206.png" alt="flecha" />
@@ -307,6 +316,7 @@ function mostrarJumpscare() {
 }
 </script>
 
+  <script src="help-modal.js"></script>
   <script src="touch-controls.js"></script>
 </body>
 </html>

--- a/Sacos.html
+++ b/Sacos.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8" />

--- a/Snake.html
+++ b/Snake.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang='es'>
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset='UTF-8'>

--- a/adivinanum.html
+++ b/adivinanum.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>

--- a/ahorcado.html
+++ b/ahorcado.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>

--- a/asteroides.html
+++ b/asteroides.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/brakeautnulls.html
+++ b/brakeautnulls.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/catala.html
+++ b/catala.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="ca">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/clicker.html
+++ b/clicker.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/enduro.css
+++ b/enduro.css
@@ -201,4 +201,5 @@ button {
   position: absolute;
   top: 10px;
   z-index: 10;
+  font-size: 16px;
 }

--- a/enduro.html
+++ b/enduro.html
@@ -1,12 +1,18 @@
 <!DOCTYPE html>
 <html>
-    <meta charset="UTF-8">
 <head>
+  <meta charset="UTF-8">
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <a href="./index.html" class="menu-button game-buttons">Menu</a>
-    <button class="help-button game-buttons" data-help="Esquiva los coches y consigue la mejor puntuación posible.">Info</button>
-
     <title>Enduro</title>
     <link rel="stylesheet" href="enduro.css" />
     <link rel="stylesheet" href="style.css" />
@@ -15,6 +21,9 @@
 </head>
 
 <body>
+
+  <a href="./index.html" class="menu-button game-buttons">Menu</a>
+  <button class="help-button game-buttons" data-help="Esquiva los coches y consigue la mejor puntuación posible.">Info</button>
 
 <div id="game">
     <div id="sky"></div>

--- a/flsppybird.html
+++ b/flsppybird.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/gente.html
+++ b/gente.html
@@ -6,13 +6,13 @@
   <title>Visitantes</title>
   <link rel="stylesheet" href="responsive.css">
   <link rel="icon" type="image/png" href="img/favicon.png">
-  <!-- Google tag (gtag.js) - replace G-XXXXXXXXXX with your own ID -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-Q25WGL1GDZ"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-    gtag('config', 'G-XXXXXXXXXX');
+    gtag('config', 'G-Q25WGL1GDZ');
   </script>
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
   <style>
@@ -30,9 +30,9 @@
   <p id="contador">Cargando...</p>
   <script>
     fetch('https://api.countapi.xyz/get/olap.es/visits')
-      .then(r => r.json())
+      .then(r => r.ok ? r.json() : Promise.reject(r))
       .then(d => {
-        document.getElementById('contador').textContent = d.value + ' personas han entrado';
+        document.getElementById('contador').textContent = d.value + ' personas han entrado a olap.es en total';
       })
       .catch(() => {
         document.getElementById('contador').textContent = 'No se pudo obtener el contador';

--- a/help-modal.js
+++ b/help-modal.js
@@ -26,11 +26,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const text = document.createElement('p');
   text.id = 'help-modal-text';
-  text.style.marginBottom = '20px';
+  Object.assign(text.style, {
+    marginBottom: '20px',
+    color: '#000',
+  });
   box.appendChild(text);
 
   const close = document.createElement('button');
   close.textContent = 'Cerrar';
+  Object.assign(close.style, {
+    fontSize: '16px',
+  });
   close.addEventListener('click', () => {
     modal.style.display = 'none';
   });

--- a/help.html
+++ b/help.html
@@ -3,6 +3,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">

--- a/ia.html
+++ b/ia.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html> 
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/iamarc/public/index.html
+++ b/iamarc/public/index.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8" />

--- a/index.html
+++ b/index.html
@@ -6,13 +6,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Olap</title>
   <link rel="icon" type="image/png" href="img/favicon.png">
-  <!-- Google tag (gtag.js) - replace G-XXXXXXXXXX with your own ID -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-Q25WGL1GDZ"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-    gtag('config', 'G-XXXXXXXXXX');
+    gtag('config', 'G-Q25WGL1GDZ');
   </script>
   <!-- Pixel font -->
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">

--- a/laberinto-3D/index.html
+++ b/laberinto-3D/index.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="en-us">
   <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="utf-8">

--- a/laberinto.html
+++ b/laberinto.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/laberinto2.html
+++ b/laberinto2.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/memory.html
+++ b/memory.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>

--- a/num.html
+++ b/num.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/pcman.html
+++ b/pcman.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />

--- a/pingpong.html
+++ b/pingpong.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/prova.html
+++ b/prova.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/proximamente.html
+++ b/proximamente.html
@@ -17,6 +17,15 @@
 
 </style>
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/robosec.html
+++ b/robosec.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/simondice.html
+++ b/simondice.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/skyhooper.html
+++ b/skyhooper.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/sonic.html
+++ b/sonic.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8" />

--- a/stickman.html
+++ b/stickman.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=0280"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '0280');
+  </script>
   <link rel="stylesheet" href="responsive.css">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="UTF-8">


### PR DESCRIPTION
## Summary
- update GA4 measurement ID on index and visitors page
- fix visitor counter by hitting CountAPI and handling errors
- show lifetime visit count on visitors page without incrementing

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68a7940656c0832fb92f87e8a9cd687e